### PR TITLE
Move encode_fp Python function from transform.py to maker.py

### DIFF
--- a/common/maker.py
+++ b/common/maker.py
@@ -12,6 +12,8 @@
 import os
 import common.file_io as io
 import common.transform as transform
+import common.utilities as utilities
+from datafingerprint import DataFingerprint
 
 
 class DocketMaker:
@@ -95,3 +97,30 @@ class DocketMaker:
 
         data = self.file_data[label]
         self.file_data[label] = transform.pad_tabular_data(data, pad_size, pad_value)
+
+
+# -------------------------------------------------------------------------
+# encode_fp
+# Encode data as fingerprint vectors. Data are expected in a tabular json
+# format (dictionary of dictionaries). See description of tabular2json
+# function for details.
+#
+# -------------------------------------------------------------------------
+def encode_fp(data_in, length):
+    # Check that data is in proper format
+    assert isinstance(data_in, dict)
+    for k, v in data_in.items():
+        assert isinstance(v, dict)
+
+    # Check that length is an int or can be converted to an int
+    assert utilities.is_integer(length)
+
+    # Calculate fingerprints
+    fp_data = {}
+    dfp = DataFingerprint(**{'length': int(length)})
+    for label, data in data_in.items():
+        dfp.recurse_structure(data)
+        fp_data[label] = dfp.fp
+        dfp.reset()
+
+    return fp_data

--- a/common/transform.py
+++ b/common/transform.py
@@ -9,8 +9,6 @@
 # https://www.python.org/dev/peps/pep-0008/#prescriptive-naming-conventions
 # -----------------------------------------------------------------------------
 import numpy as np
-import common.utilities as utilities
-from datafingerprint import DataFingerprint
 
 
 # -------------------------------------------------------------------------
@@ -75,30 +73,3 @@ def tabular2json(data, row_labels, col_labels, by_col=False, pad_rows=True):
     json_data = {level1_labels[i]: d for i, d in enumerate(second_level)}
 
     return json_data
-
-
-# -------------------------------------------------------------------------
-# encode_fp
-# Encode data as fingerprint vectors. Data are expected in a tabular json
-# format (dictionary of dictionaries). See description of tabular2json
-# function for details.
-#
-# -------------------------------------------------------------------------
-def encode_fp(data_in, length):
-    # Check that data is in proper format
-    assert isinstance(data_in, dict)
-    for k, v in data_in.items():
-        assert isinstance(v, dict)
-
-    # Check that length is an int or can be converted to an int
-    assert utilities.is_integer(length)
-
-    # Calculate fingerprints
-    fp_data = {}
-    dfp = DataFingerprint(**{'length': int(length)})
-    for label, data in data_in.items():
-        dfp.recurse_structure(data)
-        fp_data[label] = dfp.fp
-        dfp.reset()
-
-    return fp_data

--- a/scripts/compute_fp.py
+++ b/scripts/compute_fp.py
@@ -3,7 +3,7 @@
 import argparse
 
 import common.file_io as io
-import common.transform as transform
+import common.maker as make
 import common.utilities as util
 
 
@@ -14,7 +14,7 @@ def main(file, length=100, out='fp_out.json'):
     data = io.load_json(file)
 
     # Calculate fingerprints
-    data_fp = transform.encode_fp(data, length)
+    data_fp = make.encode_fp(data, length)
 
     # Convert numpy arrays to lists for conversion to json
     data_fp = {k: v.tolist() for k, v in data_fp.items()}

--- a/scripts/hello_docket.py
+++ b/scripts/hello_docket.py
@@ -4,7 +4,7 @@ from sklearn.cluster import AgglomerativeClustering
 
 import common.utilities as utilities
 import common.transform as transform
-from common.maker import DocketMaker
+import common.maker as make
 
 parser = argparse.ArgumentParser()
 
@@ -32,7 +32,7 @@ docket_params = {
     'has_index': str(args.has_index).lower() in ('true', '1')
 }
 
-dm = DocketMaker(**docket_params)
+dm = make.DocketMaker(**docket_params)
 data = dm.file_data
 
 for label, mdata in dm.file_metadata.items():
@@ -59,7 +59,7 @@ for label, mdata in dm.file_metadata.items():
     original_data = [[v for k, v in json_data[header].items()] for header in level1_headers]
 
     # Calculate fingerprints
-    fingerprints = transform.encode_fp(json_data, args.L)
+    fingerprints = make.encode_fp(json_data, args.L)
 
     # Convert to numpy array for analysis
     fp_array = np.array([data for _, data in fingerprints.items()])


### PR DESCRIPTION
The encode_fp function uses the Python implementation of data fingerprints.
To use the Python implementation of data fingerprints, one must build the
Docker image and execute within the Docker container, otherwise, the data
fingerprints Python package is not available. Since encode_fp was located
in transform.py, any code that makes use of tranform.py, even if it does
not use the Python implementation of data fingerprints, will fail.
Therefore, move encode_fp function to maker.py so that code which makes use
of functions defined in transform.py can be run outside of the Docker
container. Note that, even with this change, hello_docket.py still can only
be executed within the Docker container since it uses encode_fp. However,
hello_docket.nf was revised to use the Perl implementation of data finger-
prints rather than the Python version, so it can be run outside of the
Docker container (as long as other dependencies are satisfied). With this
change, the docket_cluster.nf script can also now be run outside of the
Docker container.