### PR TITLE
Add data-fingerprints to PERL5LIB env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN wget -qO- https://get.nextflow.io | bash \
 && pip install -r /install/requirements.txt
 
 # set perl environment variables
-ENV PERL_PATH=/home/jovyan/data-fingerprints
-ENV PERL5LIB=/app/data-fingerprints:$PERL_PATH:$PERL_PATH/lib/perl5:$PERL_PATH:$PERL5LIB
+ENV PERL_PATH=/app/data-fingerprints
+ENV PERL5LIB=$PERL_PATH:$PERL_PATH/lib/perl5:$PERL5LIB
 ENV PATH="$PERL_PATH:$PATH"
 
 # Commented out because the directory has been committed as data-fingeprints


### PR DESCRIPTION
When the docket docker container is built, the PERL5LIB environment
variable does not include the path to the data-fingerprints folder.
Therefore, add /app/data-fingerprints to PERL5LIB so that the Perl
version of data fingerprints can be found.